### PR TITLE
feat: Add initial skills and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Skills available in this repository follow the [Agent Skills format](https://age
 
 ## Available Skills
 
-| Skill | Description |
-|-------|-------------|
-| `commit` | Create commit messages following [Conventional Commits](https://www.conventionalcommits.org/) |
-| `create-pr` | Create pull requests following best engineering practices |
+| Skill       | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| `conventiona;l-commit`    | Create commit messages following [Conventional Commits](https://www.conventionalcommits.org/) |
+| `create-pr` | Create pull requests following best engineering practices                   |
 
 ## Installation
 

--- a/skills/conventional-commit/SKILL.md
+++ b/skills/conventional-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conventional-commit
-description: Create conventional commit messages following best conventions. Use when committing code changes, writing commit messages, or formatting git history. Follows conventional commits.
+description: Create conventional commit messages following best conventions. Use when committing code changes, writing commit messages, or formatting git history. Follows conventional commits specification.
 ---
 
 # Conventional Commit Messages

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: Create pull requests following best conventions. Use when opening PRs, writing PR descriptions, or preparing changes for review.
+description: Create Pull Requests following best conventions. Use when opening PRs, writing PR descriptions, or preparing changes for review.
 ---
 
 # Create Pull Request
@@ -11,14 +11,14 @@ Create pull requests following the best engineering practices.
 
 ## Prerequisites
 
-Before creating a PR, ensure all changes are committed. If there are uncommitted changes, run the commit skill `skill({ name: "commit" })` first to commit them properly.
+Before creating a PR, ensure all changes are committed. If there are uncommitted changes, run the commit skill `skill({ name: "conventional-commit" })` first to commit them properly.
 
 ```bash
 # Check for uncommitted changes
 git status --porcelain
 ```
 
-If the output shows any uncommitted changes (modified, added, or untracked files that should be included), invoke the commit skill `skill({ name: "commit" })` before proceeding.
+If the output shows any uncommitted changes (modified, added, or untracked files that should be included), invoke the commit skill `skill({ name: "conventional-commit" })` before proceeding.
 
 ## Process
 


### PR DESCRIPTION
Adds the first two skills to the repository: create-pr and commit.

Both skills follow the Agent Skills format with proper frontmatter and provide clear, actionable instructions for AI agents. The create-pr skill guides agents through creating pull requests with proper structure, while the commit skill establishes conventional commit standards.

Updates README.md to link to the AGENTS.md guide for repository conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced project documentation with overview, skills summary, and installation instructions
  * Added Conventional Commits guidelines documentation
  * Added Pull Request workflow guide documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->