### PR TITLE
fix(readme): correct installation command from add-skill to skills add

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,18 @@ npx skills add https://github.com/marcelorodrigo/agent-skills --skill create-pr
 
 ## Installation
 
-Install skills from this repository using the [add-skill](https://github.com/vercel-labs/add-skill) CLI:
+Install skills from this repository using the [skills](https://github.com/vercel-labs/skills) CLI:
 
 ```bash
 # Install all skills
-npx add-skill marcelorodrigo/agent-skills
+npx skills add marcelorodrigo/agent-skills
 
 # Install a specific skill
-npx add-skill marcelorodrigo/agent-skills --skill conventional-commit
-npx add-skill marcelorodrigo/agent-skills --skill create-pr
+npx skills add marcelorodrigo/agent-skills --skill conventional-commit
+npx skills add marcelorodrigo/agent-skills --skill create-pr
 
 # List available skills
-npx add-skill marcelorodrigo/agent-skills --list
+npx skills add marcelorodrigo/agent-skills --list
 ```
 
 ## Repository Guide


### PR DESCRIPTION
Updates the Installation section in README.md to use the correct CLI command.

The README previously referenced \"add-skill\" which is incorrect. The proper command is \"skills add\" from the Vercel Labs skills CLI. This updates all installation examples to use the correct syntax.

Changes:
- Updated link text and URL from add-skill to skills
- Changed all \"npx add-skill\" to \"npx skills add\" in installation examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated README with corrected CLI command references throughout the Installation guide and usage examples, including clear instructions for installing all available skills, installing specific individual skills, and listing available skill options for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->