### PR TITLE
fix(spring-boot-testing): Add missing mockmvc-classic and assertj-collections references

### DIFF
--- a/skills/spring-boot-testing/SKILL.md
+++ b/skills/spring-boot-testing/SKILL.md
@@ -4,7 +4,7 @@ description: Expert Spring Boot 4 testing specialist that selects the best Sprin
 license: MIT
 compatibility: Requires Spring Boot 4.0+, JUnit 6, AssertJ, Instancio, Java 25+
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Spring Boot Testing
@@ -37,15 +37,15 @@ Expert guide for testing Spring Boot 4 applications with modern patterns and bes
 
 ## Testing Tools Reference
 
-- [references/mockmvc-tester.md](references/mockmvc-tester.md) - AssertJ-style MockMvc (recommended)
-- [references/mockmvc-classic.md](references/mockmvc-classic.md) - Traditional MockMvc
+- [references/mockmvc-tester.md](references/mockmvc-tester.md) - AssertJ-style MockMvc (Spring Boot 3.2+, recommended)
+- [references/mockmvc-classic.md](references/mockmvc-classic.md) - Traditional MockMvc (pre-3.2, legacy tests, or migration guidance)
 - [references/resttestclient.md](references/resttestclient.md) - Spring Boot 4+ REST client
 - [references/mockitobean.md](references/mockitobean.md) - Mocking dependencies
 
 ## Assertion Libraries
 
-- [references/assertj-basics.md](references/assertj-basics.md) - Core AssertJ patterns
-- [references/assertj-collections.md](references/assertj-collections.md) - Collection assertions
+- [references/assertj-basics.md](references/assertj-basics.md) - Scalars, strings, booleans, dates, optionals, exceptions
+- [references/assertj-collections.md](references/assertj-collections.md) - Lists, Sets, Maps, arrays: extracting, filtering, matching elements
 
 ## Testcontainers
 

--- a/skills/spring-boot-testing/SKILL.md
+++ b/skills/spring-boot-testing/SKILL.md
@@ -37,15 +37,15 @@ Expert guide for testing Spring Boot 4 applications with modern patterns and bes
 
 ## Testing Tools Reference
 
-- [references/mockmvc-tester.md](references/mockmvc-tester.md) - AssertJ-style MockMvc (Spring Boot 3.2+, recommended)
-- [references/mockmvc-classic.md](references/mockmvc-classic.md) - Traditional MockMvc (pre-3.2, legacy tests, or migration guidance)
+- [references/mockmvc-tester.md](references/mockmvc-tester.md) - AssertJ-style MockMvc (3.2+)
+- [references/mockmvc-classic.md](references/mockmvc-classic.md) - Traditional MockMvc (pre-3.2)
 - [references/resttestclient.md](references/resttestclient.md) - Spring Boot 4+ REST client
 - [references/mockitobean.md](references/mockitobean.md) - Mocking dependencies
 
 ## Assertion Libraries
 
-- [references/assertj-basics.md](references/assertj-basics.md) - Scalars, strings, booleans, dates, optionals, exceptions
-- [references/assertj-collections.md](references/assertj-collections.md) - Lists, Sets, Maps, arrays: extracting, filtering, matching elements
+- [references/assertj-basics.md](references/assertj-basics.md) - Scalars, strings, booleans, dates
+- [references/assertj-collections.md](references/assertj-collections.md) - Lists, Sets, Maps, arrays
 
 ## Testcontainers
 

--- a/skills/spring-boot-testing/references/assertj-collections.md
+++ b/skills/spring-boot-testing/references/assertj-collections.md
@@ -33,7 +33,7 @@ assertThat(statuses).containsExactly("NEW", "PENDING", "COMPLETED");
 // Contains exactly these elements in any order (no extras)
 assertThat(statuses).containsExactlyInAnyOrder("COMPLETED", "NEW", "PENDING");
 
-// Contains at least these elements (allows extras)
+// Contains any of these elements (at least one match required)
 assertThat(statuses).containsAnyOf("NEW", "CANCELLED");
 
 // Does not contain

--- a/skills/spring-boot-testing/references/assertj-collections.md
+++ b/skills/spring-boot-testing/references/assertj-collections.md
@@ -1,0 +1,183 @@
+# AssertJ Collections
+
+AssertJ assertions for collections: `List`, `Set`, `Map`, arrays, and streams.
+
+## When to Use This Reference
+
+- The value under test is a `List`, `Set`, `Map`, array, or `Stream`
+- You need to assert on multiple elements, their order, or specific fields within them
+- You are using `extracting()`, `filteredOn()`, `containsExactly()`, or similar collection methods
+- Asserting a single scalar or single object → use [assertj-basics.md](assertj-basics.md) instead
+
+## Basic Collection Checks
+
+```java
+List<Order> orders = orderService.findAll();
+
+assertThat(orders).isNotEmpty();
+assertThat(orders).isEmpty();
+assertThat(orders).hasSize(3);
+assertThat(orders).hasSizeGreaterThan(0);
+assertThat(orders).hasSizeLessThanOrEqualTo(10);
+```
+
+## Containment Assertions
+
+```java
+// Contains (any order, allows extras)
+assertThat(orders).contains(order1, order2);
+
+// Contains exactly these elements in this order (no extras)
+assertThat(statuses).containsExactly("NEW", "PENDING", "COMPLETED");
+
+// Contains exactly these elements in any order (no extras)
+assertThat(statuses).containsExactlyInAnyOrder("COMPLETED", "NEW", "PENDING");
+
+// Contains at least these elements (allows extras)
+assertThat(statuses).containsAnyOf("NEW", "CANCELLED");
+
+// Does not contain
+assertThat(statuses).doesNotContain("DELETED");
+```
+
+## Extracting Fields
+
+Extract a single field from each element before asserting:
+
+```java
+assertThat(orders)
+  .extracting(Order::getStatus)
+  .containsExactly("NEW", "PENDING", "COMPLETED");
+```
+
+Extract multiple fields as tuples:
+
+```java
+assertThat(orders)
+  .extracting(Order::getId, Order::getStatus)
+  .containsExactly(
+    tuple(1L, "NEW"),
+    tuple(2L, "PENDING"),
+    tuple(3L, "COMPLETED")
+  );
+```
+
+## Filtering Before Asserting
+
+```java
+assertThat(orders)
+  .filteredOn(order -> order.getStatus().equals("PENDING"))
+  .hasSize(2)
+  .extracting(Order::getId)
+  .containsExactlyInAnyOrder(1L, 3L);
+
+// Filter by field value
+assertThat(orders)
+  .filteredOn("status", "PENDING")
+  .hasSize(2);
+```
+
+## Predicate Checks
+
+```java
+assertThat(orders).allMatch(o -> o.getTotal().compareTo(BigDecimal.ZERO) > 0);
+assertThat(orders).anyMatch(o -> o.getStatus().equals("COMPLETED"));
+assertThat(orders).noneMatch(o -> o.getStatus().equals("DELETED"));
+
+// With description for failure messages
+assertThat(orders)
+  .allSatisfy(o -> assertThat(o.getId()).isPositive());
+```
+
+## Per-Element Ordered Assertions
+
+Assert each element in order with individual conditions:
+
+```java
+assertThat(orders).satisfiesExactly(
+  first  -> assertThat(first.getStatus()).isEqualTo("NEW"),
+  second -> assertThat(second.getStatus()).isEqualTo("PENDING"),
+  third  -> {
+    assertThat(third.getStatus()).isEqualTo("COMPLETED");
+    assertThat(third.getTotal()).isGreaterThan(BigDecimal.ZERO);
+  }
+);
+```
+
+## Nested / Flat Collections
+
+```java
+// flatExtracting: flatten one level of nested collections
+assertThat(orders)
+  .flatExtracting(Order::getItems)
+  .extracting(OrderItem::getProduct)
+  .contains("Laptop", "Mouse");
+```
+
+## Recursive Field Comparison
+
+Compare elements by fields instead of object identity:
+
+```java
+assertThat(orders)
+  .usingRecursiveFieldByFieldElementComparator()
+  .containsExactlyInAnyOrder(expectedOrder1, expectedOrder2);
+
+// Ignore specific fields (e.g. generated IDs or timestamps)
+assertThat(orders)
+  .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "createdAt")
+  .containsExactly(expectedOrder1, expectedOrder2);
+```
+
+## Map Assertions
+
+```java
+Map<String, Integer> stockByProduct = inventoryService.getStock();
+
+assertThat(stockByProduct)
+  .isNotEmpty()
+  .hasSize(3)
+  .containsKey("Laptop")
+  .doesNotContainKey("Fax Machine")
+  .containsEntry("Laptop", 10)
+  .containsEntries(entry("Laptop", 10), entry("Mouse", 50));
+
+assertThat(stockByProduct)
+  .hasEntrySatisfying("Laptop", qty -> assertThat(qty).isGreaterThan(0));
+```
+
+## Array Assertions
+
+```java
+String[] roles = user.getRoles();
+
+assertThat(roles).hasSize(2);
+assertThat(roles).contains("ADMIN");
+assertThat(roles).containsExactlyInAnyOrder("USER", "ADMIN");
+```
+
+## Set Assertions
+
+```java
+Set<String> tags = product.getTags();
+
+assertThat(tags).contains("electronics", "sale");
+assertThat(tags).doesNotContain("expired");
+assertThat(tags).hasSizeGreaterThanOrEqualTo(1);
+```
+
+## Static Import
+
+```java
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.Assertions.entry;
+```
+
+## Key Points
+
+1. **`containsExactly` vs `containsExactlyInAnyOrder`** — use the former when order matters
+2. **`extracting()` before containment checks** — avoids implementing `equals()` on domain objects
+3. **`filteredOn()` + `extracting()`** — compose to assert a subset of a collection precisely
+4. **`satisfiesExactly()`** — use when each element needs different assertions
+5. **`usingRecursiveFieldByFieldElementComparator()`** — preferred over `equals()` for DTOs and records

--- a/skills/spring-boot-testing/references/mockmvc-classic.md
+++ b/skills/spring-boot-testing/references/mockmvc-classic.md
@@ -1,0 +1,205 @@
+# MockMvc Classic
+
+Traditional MockMvc API for Spring MVC controller tests (pre-Spring Boot 3.2 or legacy codebases).
+
+## When to Use This Reference
+
+- The project uses Spring Boot < 3.2 (no `MockMvcTester` available)
+- Existing tests use `mvc.perform(...)` and you are maintaining or extending them
+- You need to migrate classic MockMvc tests to `MockMvcTester` (see migration section below)
+- The user explicitly asks about `ResultActions`, `andExpect()`, or Hamcrest-style web assertions
+
+For new tests on Spring Boot 3.2+, prefer [mockmvc-tester.md](mockmvc-tester.md) instead.
+
+## Setup
+
+```java
+@WebMvcTest(OrderController.class)
+class OrderControllerTest {
+
+  @Autowired
+  private MockMvc mvc;
+
+  @MockitoBean
+  private OrderService orderService;
+}
+```
+
+## Basic GET Request
+
+```java
+@Test
+void shouldReturnOrder() throws Exception {
+  given(orderService.findById(1L)).willReturn(new Order(1L, "PENDING", 99.99));
+
+  mvc.perform(get("/orders/1"))
+    .andExpect(status().isOk())
+    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+    .andExpect(jsonPath("$.id").value(1))
+    .andExpect(jsonPath("$.status").value("PENDING"))
+    .andExpect(jsonPath("$.totalToPay").value(99.99));
+}
+```
+
+## POST with Request Body
+
+```java
+@Test
+void shouldCreateOrder() throws Exception {
+  given(orderService.create(any(OrderRequest.class))).willReturn(1L);
+
+  mvc.perform(post("/orders")
+      .contentType(MediaType.APPLICATION_JSON)
+      .content("{\"product\": \"Laptop\", \"quantity\": 2}"))
+    .andExpect(status().isCreated())
+    .andExpect(header().string("Location", "/orders/1"));
+}
+```
+
+## PUT Request
+
+```java
+@Test
+void shouldUpdateOrder() throws Exception {
+  mvc.perform(put("/orders/1")
+      .contentType(MediaType.APPLICATION_JSON)
+      .content("{\"status\": \"COMPLETED\"}"))
+    .andExpect(status().isOk());
+}
+```
+
+## DELETE Request
+
+```java
+@Test
+void shouldDeleteOrder() throws Exception {
+  mvc.perform(delete("/orders/1"))
+    .andExpect(status().isNoContent());
+}
+```
+
+## Status Matchers
+
+```java
+.andExpect(status().isOk())           // 200
+.andExpect(status().isCreated())      // 201
+.andExpect(status().isNoContent())    // 204
+.andExpect(status().isBadRequest())   // 400
+.andExpect(status().isUnauthorized()) // 401
+.andExpect(status().isForbidden())    // 403
+.andExpect(status().isNotFound())     // 404
+.andExpect(status().is(422))          // arbitrary code
+```
+
+## JSON Path Assertions
+
+```java
+// Exact value
+.andExpect(jsonPath("$.status").value("PENDING"))
+
+// Existence
+.andExpect(jsonPath("$.id").exists())
+.andExpect(jsonPath("$.deletedAt").doesNotExist())
+
+// Array size
+.andExpect(jsonPath("$.items").isArray())
+.andExpect(jsonPath("$.items", hasSize(3)))
+
+// Nested field
+.andExpect(jsonPath("$.customer.name").value("John Doe"))
+.andExpect(jsonPath("$.customer.address.city").value("Berlin"))
+
+// With Hamcrest matchers
+.andExpect(jsonPath("$.total", greaterThan(0.0)))
+.andExpect(jsonPath("$.description", containsString("order")))
+```
+
+## Content Assertions
+
+```java
+.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+.andExpect(content().string(containsString("PENDING")))
+.andExpect(content().json("{\"status\":\"PENDING\"}"))
+```
+
+## Header Assertions
+
+```java
+.andExpect(header().string("Location", "/orders/1"))
+.andExpect(header().string("Content-Type", containsString("application/json")))
+.andExpect(header().exists("X-Request-Id"))
+.andExpect(header().doesNotExist("X-Deprecated"))
+```
+
+## Request Parameters and Headers
+
+```java
+// Query parameters
+mvc.perform(get("/orders").param("status", "PENDING").param("page", "0"))
+  .andExpect(status().isOk());
+
+// Path variables
+mvc.perform(get("/orders/{id}", 1L))
+  .andExpect(status().isOk());
+
+// Request headers
+mvc.perform(get("/orders/1").header("X-Api-Key", "secret"))
+  .andExpect(status().isOk());
+```
+
+## Capturing the Response
+
+```java
+@Test
+void shouldReturnCreatedId() throws Exception {
+  given(orderService.create(any())).willReturn(42L);
+
+  MvcResult result = mvc.perform(post("/orders")
+      .contentType(MediaType.APPLICATION_JSON)
+      .content("{\"product\": \"Laptop\", \"quantity\": 1}"))
+    .andExpect(status().isCreated())
+    .andReturn();
+
+  String location = result.getResponse().getHeader("Location");
+  assertThat(location).isEqualTo("/orders/42");
+}
+```
+
+## Chaining with andDo
+
+```java
+mvc.perform(get("/orders/1"))
+  .andDo(print())              // prints request/response to console (debug)
+  .andExpect(status().isOk());
+```
+
+## Static Imports
+
+```java
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.hamcrest.Matchers.*;
+```
+
+## Migration to MockMvcTester
+
+| Classic MockMvc | MockMvcTester (recommended) |
+|---|---|
+| `@Autowired MockMvc mvc` | `@Autowired MockMvcTester mvc` |
+| `mvc.perform(get("/orders/1"))` | `mvc.get().uri("/orders/1")` |
+| `.andExpect(status().isOk())` | `.hasStatusOk()` |
+| `.andExpect(jsonPath("$.status").value("X"))` | `.bodyJson().convertTo(T.class)` + AssertJ |
+| `throws Exception` on every method | No checked exception |
+| Hamcrest matchers | AssertJ fluent assertions |
+
+See [mockmvc-tester.md](mockmvc-tester.md) for the full modern API.
+
+## Key Points
+
+1. **Every test method must declare `throws Exception`** — `perform()` throws checked exceptions
+2. **Use `andDo(print())` during debugging** — remove before committing
+3. **Prefer `jsonPath()` over `content().string()`** — more precise field-level assertions
+4. **Static imports are required** — IDE can auto-add them
+5. **Migrate to MockMvcTester** when upgrading to Spring Boot 3.2+ for better readability

--- a/skills/spring-boot-testing/references/mockmvc-classic.md
+++ b/skills/spring-boot-testing/references/mockmvc-classic.md
@@ -20,7 +20,7 @@ class OrderControllerTest {
   @Autowired
   private MockMvc mvc;
 
-  @MockitoBean
+  @MockBean
   private OrderService orderService;
 }
 ```
@@ -177,6 +177,7 @@ mvc.perform(get("/orders/1"))
 ## Static Imports
 
 ```java
+import org.springframework.boot.test.mock.mockito.MockBean;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;


### PR DESCRIPTION
Closes #14

Two reference files declared in `SKILL.md` were missing from the repository, causing 404 errors when accessed. Reported by @dbelyaev.

**Added:**
- `references/mockmvc-classic.md` — traditional `MockMvc` API (`mvc.perform()`, `ResultActions`, Hamcrest matchers) for pre-3.2 codebases, with a migration table pointing to `MockMvcTester`
- `references/assertj-collections.md` — AssertJ collection assertions: containment, `extracting()`, `filteredOn()`, `satisfiesExactly()`, recursive comparators, Map/array/Set support

**Updated:**
- `SKILL.md` index entries for both files now include a brief "use when" descriptor so the agent can select the right reference at decision time without opening every file
- Version bumped to `1.1.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testing references with Spring Boot 3.2+ guidance and migration notes.
  * Added comprehensive AssertJ collections reference with examples and usage notes.
  * Added classic MockMvc reference covering setup, request/response assertions, patterns, and migration guidance.
  * Expanded assertion library descriptions for scalars, strings, booleans, dates, lists, sets, maps, arrays.

* **Chores**
  * Version bumped to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->