### PR TITLE
fix(conventional-commit): align subject casing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
 **Subject rules**:
 - Maximum 70 characters
 - Use imperative, present tense
-- Capitalize first letter
+- Do not capitalize the first letter
 - No period at the end
 
 **Branch naming**: `<type>/<short-description>`

--- a/skills/conventional-commit/SKILL.md
+++ b/skills/conventional-commit/SKILL.md
@@ -59,8 +59,8 @@ The header is required. Scope is optional. All lines must stay under 100 charact
 
 ## Subject Line Rules
 
-- Use imperative, present tense: "Add feature" not "Added feature"
-- Capitalize the first letter
+- Use imperative, present tense: "add feature" not "added feature"
+- Do not capitalize the first letter
 - No period at the end
 - Maximum 70 characters
 
@@ -86,7 +86,7 @@ The commit contains the following structural elements, to communicate intent to 
 ### Simple fix
 
 ```
-fix(api): Handle null response in user endpoint
+fix(api): handle null response in user endpoint
 
 The user API could return null for deleted accounts, causing a crash
 in the dashboard. Add null check before accessing user properties.
@@ -95,7 +95,7 @@ in the dashboard. Add null check before accessing user properties.
 ### Feature with scope
 
 ```
-feat(alerts): Add Slack thread replies for alert updates
+feat(alerts): add Slack thread replies for alert updates
 
 When an alert is updated or resolved, post a reply to the original
 Slack thread instead of creating a new message. This keeps related
@@ -105,7 +105,7 @@ notifications grouped together.
 ### Refactor
 
 ```
-refactor: Extract common validation logic to shared module
+refactor: extract common validation logic to shared module
 
 Move duplicate validation code from three endpoints into a shared
 validator class. No behavior change.
@@ -114,7 +114,7 @@ validator class. No behavior change.
 ### Breaking change
 
 ```
-feat(api)!: Remove deprecated v1 endpoints
+feat(api)!: remove deprecated v1 endpoints
 
 Remove all v1 API endpoints that were deprecated in version 23.1.
 Clients should migrate to v2 endpoints.
@@ -125,7 +125,7 @@ BREAKING CHANGE: v1 endpoints no longer available
 ## Revert Format
 
 ```
-revert: feat(api): Add new endpoint
+revert: feat(api): add new endpoint
 
 This reverts commit abc123def456.
 

--- a/skills/conventional-commit/SKILL.md
+++ b/skills/conventional-commit/SKILL.md
@@ -3,7 +3,7 @@ name: conventional-commit
 description: Create conventional commit messages following best conventions. Use when committing code changes, writing commit messages, or formatting git history. Follows conventional commits specification.
 license: MIT
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Conventional Commit Messages


### PR DESCRIPTION
This removes the instruction to capitalize conventional commit subjects and replaces it with lower-case subject guidance.

The conventional-commit skill examples now use lower-case subjects so they match the rule, and AGENTS.md now has the same casing guidance for repository commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated commit-message guidance to require lowercase, imperative subject lines (no capitalization of the first letter).
  * Adjusted multiple commit-message examples to match the updated subject-line rule.
  * Bumped the skill documentation version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->